### PR TITLE
fix(docker): fix production image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:14-alpine as dev
 
 RUN mkdir -p /srv/app
 WORKDIR /srv/app
-#EXPOSE 3000
+EXPOSE 3000
 
 ENV NODE_ENV=development
 CMD ["npm", "run", "start:dev"]
@@ -27,7 +27,8 @@ FROM node:14-alpine
 
 RUN mkdir -p /srv/app
 WORKDIR /srv/app
-#EXPOSE 3000
+USER node
+EXPOSE 3000
 
 ENV NODE_ENV=production
 CMD ["node", "dist/main.js"]
@@ -35,4 +36,5 @@ CMD ["node", "dist/main.js"]
 # copy built files (including built native node_modules)
 COPY package.json package-lock.json /srv/app/
 COPY --from=builder /srv/app/node_modules/ /srv/app/node_modules/
+COPY --from=builder /srv/app/src/schema/*.graphql /srv/app/dist/schema/
 COPY --from=builder /srv/app/dist/ /srv/app/dist/

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,10 +14,12 @@ import { DatabaseModule } from './database/database.module';
     TerminusModule,
     GraphQLModule.forRoot({
       typePaths: ['./**/*.graphql'],
-      definitions: {
-        path: join(process.cwd(), 'src/schema/index.ts'),
-        outputAs: 'class',
-      },
+      ...(process.env.NODE_ENV === 'development' && {
+        definitions: {
+          path: join(process.cwd(), 'src/schema/index.ts'),
+          outputAs: 'class',
+        },
+      }),
       resolvers: {
         JSON: GraphQLJSON,
         JSONObject: GraphQLJSONObject,


### PR DESCRIPTION
Make the production image run as node instead of root, and prevent the attempt to build schema.index.ts.