### PR TITLE
fix: fix merge function and diff

### DIFF
--- a/src/app.service.spec.ts
+++ b/src/app.service.spec.ts
@@ -1,0 +1,130 @@
+import { NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AppService } from './app.service';
+import { DatabaseModule, DatabaseService } from './database';
+
+describe('AppService', () => {
+  let service: AppService;
+  let db: DatabaseService;
+  let dbSpy;
+
+  const collection = 'tests';
+  const system = 'mock-system';
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      imports: [DatabaseModule.register('mockdb')],
+      providers: [AppService],
+    }).compile();
+
+    service = module.get<AppService>(AppService);
+    db = module.get<DatabaseService>(DatabaseService);
+
+    dbSpy = {
+      load: jest.spyOn(db, 'load'),
+      create: jest.spyOn(db, 'create'),
+      update: jest.spyOn(db, 'update'),
+      createEvent: jest.spyOn(db, 'createEvent'),
+    };
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  it('should create records', async () => {
+    const id = 'new';
+    const name = 'test';
+    const ref = { collection, system, id };
+    const input = {
+      system,
+      id,
+      name,
+      content: { id, name },
+    };
+
+    dbSpy.load.mockImplementationOnce(() => {
+      throw new NotFoundException();
+    });
+
+    const result = await service.save(ref, input);
+
+    expect(dbSpy.update).not.toBeCalled();
+    expect(dbSpy.create).toBeCalledWith(collection, input);
+    expect(dbSpy.createEvent).toBeCalledWith(
+      ref,
+      expect.objectContaining({
+        changes: expect.arrayContaining([
+          {
+            op: 'add',
+            path: '/id',
+            value: id,
+          },
+        ]),
+      }),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        system,
+        id,
+        name,
+      }),
+    );
+
+    expect(result.globalId).toBeUndefined();
+  });
+
+  it('should update records', async () => {
+    const id = 'mock-1234';
+    const name = 'test';
+    const ref = { collection, system, id };
+    const input = {
+      system,
+      id,
+      name,
+      content: { id, name },
+    };
+
+    const result = await service.save(ref, input);
+
+    expect(dbSpy.create).not.toBeCalled();
+    expect(dbSpy.update).toBeCalledWith(ref, input);
+    expect(dbSpy.createEvent).toBeCalledWith(
+      ref,
+      expect.objectContaining({
+        changes: expect.arrayContaining([
+          {
+            op: 'replace',
+            path: '/name',
+            value: name,
+          },
+        ]),
+      }),
+    );
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        system,
+        id,
+        name,
+      }),
+    );
+
+    expect(result.globalId).toBeUndefined();
+  });
+
+  it('should not save empty events', async () => {
+    const id = 'mock-1234';
+    const ref = { collection, system, id };
+
+    const { createdAt, updatedAt, ...input } = await db.load(ref);
+
+    const result = await service.save(ref, input);
+
+    expect(dbSpy.update).toBeCalledWith(ref, input);
+    expect(dbSpy.createEvent).not.toBeCalled();
+
+    expect(result.event?.changes).toEqual([]);
+  });
+});

--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -52,20 +52,21 @@ export abstract class DatabaseService implements DbConnection {
   async create(
     collection: string,
     document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]> {
+  ): Promise<DbDocument> {
     return this.withTransaction((conn) => {
-      return conn.create(collection, document, changes);
+      return conn.create(collection, document);
     });
   }
 
-  async update(
-    ref: Ref,
-    document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]> {
+  async update(ref: Ref, document: DocumentInput): Promise<DbDocument> {
     return this.withTransaction((conn) => {
-      return conn.update(ref, document, changes);
+      return conn.update(ref, document);
+    });
+  }
+
+  async createEvent(ref: Ref, event: DbEvent): Promise<DbEvent> {
+    return this.withTransaction((conn) => {
+      return conn.createEvent(ref, event);
     });
   }
 

--- a/src/database/interfaces/db-connection.interface.ts
+++ b/src/database/interfaces/db-connection.interface.ts
@@ -34,17 +34,11 @@ export interface DbConnection {
     options?: ListOptions,
   ): Promise<[DbDocument[], number?]>;
 
-  create(
-    collection: string,
-    document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]>;
+  create(collection: string, document: DocumentInput): Promise<DbDocument>;
 
-  update(
-    ref: Ref,
-    document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]>;
+  update(ref: Ref, document: DocumentInput): Promise<DbDocument>;
+
+  createEvent(ref: Ref, event: DbEvent): Promise<DbEvent>;
 
   delete(ref: Ref, options?: DeleteOptions): Promise<DbDocument>;
 }

--- a/src/database/mockdb/mockdb.service.ts
+++ b/src/database/mockdb/mockdb.service.ts
@@ -99,28 +99,20 @@ export class MockdbService extends DatabaseService {
   async create(
     collection: string,
     document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]> {
-    return [
-      {
-        ...document,
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-      {
-        at: new Date(),
-        name: document.event?.name,
-        changes,
-      },
-    ];
+  ): Promise<DbDocument> {
+    return {
+      ...document,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
   }
 
-  async update(
-    ref: Ref,
-    document: DocumentInput,
-    changes: Change[],
-  ): Promise<[DbDocument, DbEvent]> {
-    return this.create(ref.collection, document, changes);
+  async update(ref: Ref, document: DocumentInput): Promise<DbDocument> {
+    return {
+      ...document,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
   }
 
   async delete(
@@ -135,6 +127,10 @@ export class MockdbService extends DatabaseService {
       content: { id, name: `mock ${collection}` },
       deletedAt: options?.deletedAt ? new Date(options?.deletedAt) : new Date(),
     };
+  }
+
+  async createEvent(ref: Ref, event: DbEvent): Promise<DbEvent> {
+    return event;
   }
 
   async withTransaction<T>(

--- a/src/schema/mutations.graphql
+++ b/src/schema/mutations.graphql
@@ -49,6 +49,6 @@ input DocumentInput {
 }
 
 input EventInput {
-  "The nname or description of the event"
+  "The name or description of the event"
   name: String
 }


### PR DESCRIPTION
The merge option applies to the content, not the metadata. The diff is now based on what's saved,
not what is passed through. (If content isn't passed in, the content in the db doesn't change, but
the event looked it was.)