### PR TITLE
fix(mariadb): retry deadlock errors during insert

### DIFF
--- a/src/database/database.service.ts
+++ b/src/database/database.service.ts
@@ -38,7 +38,9 @@ export abstract class DatabaseService implements DbConnection {
         if (!this.shouldRetry(error)) {
           throw error;
         }
-        this.logger.debug(`Failed transaction attempt: ${error.message}`);
+        this.logger.debug(
+          `Failed transaction attempt: ${error.message.replace(/\n/g, ' ')}`,
+        );
         lastError = error;
       }
     }

--- a/src/database/mariadb/mariadb.service.ts
+++ b/src/database/mariadb/mariadb.service.ts
@@ -63,6 +63,9 @@ export class MariadbService
       if (error.errno === 1062) {
         // we should only get a duplicate if an event timestamp matches exactly
         return true;
+      } else if (error.errno === 1213) {
+        // Deadlock found when trying to get lock; try restarting transaction
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
Also improves the insert performance by using RETURNING *, which is was added in Mariadb 10.5, and
remove newlines from logs.