### PR TITLE
fix(mariadb): fix database deadlocks on insert

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,6 +17,7 @@ module.exports = {
   },
   ignorePatterns: ['.eslintrc.js'],
   rules: {
+    'prettier/prettier': 'warn',
     '@typescript-eslint/interface-name-prefix': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/explicit-module-boundary-types': 'off',

--- a/src/database/mariadb/mariadb.service.ts
+++ b/src/database/mariadb/mariadb.service.ts
@@ -45,7 +45,9 @@ export class MariadbService
       conn = await this.pool.getConnection();
       await conn.beginTransaction();
 
-      const results = await duringTransaction(new MariadbConnection(conn));
+      const results = await duringTransaction(
+        new MariadbConnection(conn, true),
+      );
 
       await conn.commit();
       return results;


### PR DESCRIPTION
The SELECT ... FOR UPDATE locks more than necessary when the record isn't found, which was creating deadlocks even between inserts with different ids. By committing and releasing the lock when the record isn't found, we will get duplicate entry errors, but only if it's the same id. Since we already have retry logic in place for duplicates and deadlocks, the update still goes through.